### PR TITLE
Minor automated testing tweaks.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,10 @@ matrix:
     # aliased to a recent 5.6.x version
     - php: '5.6'
       env: SNIFF=1
-    # aliased to a recent 7.x version
+    # aliased to a recent 7.0.x version
     - php: '7.0'
+    # aliased to a recent 7.1.x version
+    - php: '7.1'
     # aliased to a recent hhvm version
     - php: 'hhvm'
 

--- a/cmb2-admin-extension.php
+++ b/cmb2-admin-extension.php
@@ -163,7 +163,7 @@ class CMB2_Admin_Extension_Class {
 
 		?>
 			<div class="error">
-				<p><?php printf( esc_html__( 'CMB2 Admin Extension depends on the last version of %s the CMB2 plugin %s to work!', 'cmb2-admin-extension' ), '<a href="https://wordpress.org/plugins/cmb2/">', '</a>' ); ?></p>
+				<p><?php printf( esc_html__( 'CMB2 Admin Extension depends on the last version of %1$s the CMB2 plugin %2$s to work!', 'cmb2-admin-extension' ), '<a href="https://wordpress.org/plugins/cmb2/">', '</a>' ); ?></p>
 			</div>
 		<?php
 
@@ -178,7 +178,7 @@ class CMB2_Admin_Extension_Class {
 
 		?>
 			<div class="error">
-				<p><?php printf( esc_html__( 'The CMB2 plugin is installed but has not been activated. Please %s activate %s it to use the CMB2 Admin Extension', 'cmb2-admin-extension' ), '<a href="' . esc_url( admin_url( 'plugins.php' ) ) . '">', '</a>' ); ?></p>
+				<p><?php printf( esc_html__( 'The CMB2 plugin is installed but has not been activated. Please %1$s activate %2$s it to use the CMB2 Admin Extension', 'cmb2-admin-extension' ), '<a href="' . esc_url( admin_url( 'plugins.php' ) ) . '">', '</a>' ); ?></p>
 			</div>
 		<?php
 

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -2,6 +2,12 @@
 <ruleset name="CMB2 Admin Extension">
 	<description>The code standard for CMB2 Admin Extension is WordPress.</description>
 
+	<!-- ##### Sniffs for PHP cross-version compatibility ##### -->
+	<config name="testVersion" value="5.2-99.0"/>
+	<rule ref="PHPCompatibility"/>
+
+
+	<!-- ##### Code style ##### -->
 	<rule ref="WordPress">
 		<exclude name="WordPress.VIP.PostsPerPage.posts_per_page" />
 		<exclude name="WordPress.PHP.YodaConditions.NotYoda" />


### PR DESCRIPTION
* 	Add sniffing for cross-PHP version compatibility to the PHPCS ruleset.
*  	Add PHP 7.1 to the travis test matrix as it will be released soon.
*  	Minor code style fix in anticipation of the WPCS 0.10.0 release.