### PR TITLE
Update the travis script & the PHPCS ruleset and fix the codebase

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -17,11 +17,25 @@
 
 	<!-- ##### Code style ##### -->
 	<rule ref="WordPress">
-		<exclude name="WordPress.VIP.PostsPerPage.posts_per_page" />
-		<exclude name="WordPress.PHP.YodaConditions.NotYoda" />
+		<exclude name="WordPress.VIP.PostsPerPage.posts_per_page_posts_per_page"/>
+		<exclude name="WordPress.PHP.YodaConditions.NotYoda"/>
 	</rule>
 
-	<!-- exclude the 'empty' index files from some documentation checks -->
+	<rule ref="WordPress.Arrays.MultipleStatementAlignment">
+		<properties>
+			<property name="exact" value="false"/>
+			<property name="ignoreNewlines" value="false"/>
+			<property name="alignMultilineItems" value="!=100"/>
+		</properties>
+	</rule>
+
+	<rule ref="WordPress.Files.FileName">
+		<properties>
+			<property name="strict_class_file_names" value="false"/>
+		</properties>
+	</rule>
+
+	<!-- Exclude the 'empty' index files from some documentation checks -->
 	<rule ref="Squiz.Commenting.FileComment.WrongStyle">
 		<exclude-pattern>*/index\.php</exclude-pattern>
 	</rule>

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -2,6 +2,14 @@
 <ruleset name="CMB2 Admin Extension">
 	<description>The code standard for CMB2 Admin Extension is WordPress.</description>
 
+	<!-- Show progress & sniff codes. -->
+	<arg value="ps"/>
+	<!-- Only check PHP files. -->
+	<arg name="extensions" value="php"/>
+
+	<!-- Check all files in this directory and the directories below it. -->
+	<file>.</file>
+
 	<!-- ##### Sniffs for PHP cross-version compatibility ##### -->
 	<config name="testVersion" value="5.2-99.0"/>
 	<rule ref="PHPCompatibility"/>
@@ -15,10 +23,10 @@
 
 	<!-- exclude the 'empty' index files from some documentation checks -->
 	<rule ref="Squiz.Commenting.FileComment.WrongStyle">
-		<exclude-pattern>*/index.php</exclude-pattern>
+		<exclude-pattern>*/index\.php</exclude-pattern>
 	</rule>
 	<rule ref="Squiz.Commenting.InlineComment.SpacingAfter">
-		<exclude-pattern>*/index.php</exclude-pattern>
+		<exclude-pattern>*/index\.php</exclude-pattern>
 	</rule>
 
 </ruleset>

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@
 # Use new container based environment
 sudo: false
 
+dist: trusty
+
 # Declare project language.
 # @link http://about.travis-ci.org/docs/user/languages/php/
 language: php
@@ -16,15 +18,16 @@ matrix:
     # Current $required_php_version for WordPress: 5.2.4
     # aliased to 5.2.17
     - php: '5.2'
+      dist: precise
     # aliased to a recent 5.4.x version
     - php: '5.4'
     # aliased to a recent 5.6.x version
     - php: '5.6'
-      env: SNIFF=1
     # aliased to a recent 7.0.x version
     - php: '7.0'
-    # aliased to a recent 7.1.x version
-    - php: '7.1'
+      env: SNIFF=1
+    # aliased to a recent 7.2.x version
+    - php: '7.2'
     # aliased to a recent hhvm version
     - php: 'hhvm'
 
@@ -33,16 +36,17 @@ matrix:
 
 before_script:
     - export PHPCS_DIR=/tmp/phpcs
-    - export SNIFFS_DIR=/tmp/sniffs
-    # Install CodeSniffer for WordPress Coding Standards checks.
+    - export WPCS_DIR=/tmp/wpcs
+    - export PHPCOMPAT_DIR=/tmp/phpcompatibility
+    # Install PHP CodeSniffer for Coding Standards checks.
     - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/squizlabs/PHP_CodeSniffer.git $PHPCS_DIR; fi
     # Install WordPress Coding Standards.
-    - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git $SNIFFS_DIR; fi
+    - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git $WPCS_DIR; fi
     # Install PHP Compatibility sniffs.
-    - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/wimg/PHPCompatibility.git $SNIFFS_DIR/PHPCompatibility; fi
-    # Set install path for WordPress Coding Standards.
+    - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/wimg/PHPCompatibility.git $PHPCOMPAT_DIR; fi
+    # Set install path for PHPCS sniffs.
     # @link https://github.com/squizlabs/PHP_CodeSniffer/blob/4237c2fc98cc838730b76ee9cee316f99286a2a7/CodeSniffer.php#L1941
-    - if [[ "$SNIFF" == "1" ]]; then $PHPCS_DIR/scripts/phpcs --config-set installed_paths $SNIFFS_DIR; fi
+    - if [[ "$SNIFF" == "1" ]]; then $PHPCS_DIR/bin/phpcs --config-set installed_paths $WPCS_DIR,$PHPCOMPAT_DIR; fi
     # After CodeSniffer install you should refresh your path.
     - if [[ "$SNIFF" == "1" ]]; then phpenv rehash; fi
     # Install JSCS: JavaScript Code Style checker.
@@ -63,16 +67,13 @@ script:
     - if [[ "$SNIFF" == "1" ]]; then jshint .; fi
     # Run through JavaScript Code Style checker.
     - if [[ "$SNIFF" == "1" ]]; then jscs .; fi
-    # WordPress Coding Standards.
+    # Check code against the WordPress Coding Standards and for PHP cross-version compatibility.
     # @link https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+    # @link https://github.com/wimg/phpcompatibility
     # @link http://pear.php.net/package/PHP_CodeSniffer/
-    # -p flag: Show progress of the run.
-    # -s flag: Show sniff codes in all reports.
-    # -v flag: Print verbose output.
-    # -n flag: Do not print warnings. (shortcut for --warning-severity=0)
-    # --standard: Use WordPress as the standard.
-    # --extensions: Only sniff PHP files.
-    - if [[ "$SNIFF" == "1" ]]; then $PHPCS_DIR/scripts/phpcs -p -s -v -n . --standard=./phpcs.xml --extensions=php; fi
+    # Uses a custom ruleset based on WordPress.
+    # Only fails the build on errors, not warnings, but still show warnings in the output.
+    - if [[ "$SNIFF" == "1" ]]; then $PHPCS_DIR/bin/phpcs --runtime-set ignore_warnings_on_exit 1; fi
 
 # Receive notifications for build results.
 # @link http://docs.travis-ci.com/user/notifications/#Email-notifications

--- a/cmb2-admin-extension.php
+++ b/cmb2-admin-extension.php
@@ -102,7 +102,7 @@ class CMB2_Admin_Extension_Class {
 	public static function get_instance() {
 		// If the single instance hasn't been set, set it now.
 		if ( null === self::$instance ) {
-			self::$instance = new self;
+			self::$instance = new self();
 		}
 
 		return self::$instance;
@@ -163,7 +163,16 @@ class CMB2_Admin_Extension_Class {
 
 		?>
 			<div class="error">
-				<p><?php printf( esc_html__( 'CMB2 Admin Extension depends on the last version of %1$s the CMB2 plugin %2$s to work!', 'cmb2-admin-extension' ), '<a href="https://wordpress.org/plugins/cmb2/">', '</a>' ); ?></p>
+				<p>
+					<?php
+					printf(
+						/* translators: 1: link opener; 2: link closer. */
+						esc_html__( 'CMB2 Admin Extension depends on the last version of %1$s the CMB2 plugin %2$s to work!', 'cmb2-admin-extension' ),
+						'<a href="https://wordpress.org/plugins/cmb2/">',
+						'</a>'
+					);
+					?>
+				</p>
 			</div>
 		<?php
 
@@ -178,7 +187,16 @@ class CMB2_Admin_Extension_Class {
 
 		?>
 			<div class="error">
-				<p><?php printf( esc_html__( 'The CMB2 plugin is installed but has not been activated. Please %1$s activate %2$s it to use the CMB2 Admin Extension', 'cmb2-admin-extension' ), '<a href="' . esc_url( admin_url( 'plugins.php' ) ) . '">', '</a>' ); ?></p>
+				<p>
+					<?php
+					printf(
+						/* translators: 1: link opener; 2: link closer. */
+						esc_html__( 'The CMB2 plugin is installed but has not been activated. Please %1$s activate %2$s it to use the CMB2 Admin Extension', 'cmb2-admin-extension' ),
+						'<a href="' . esc_url( admin_url( 'plugins.php' ) ) . '">',
+						'</a>'
+					);
+					?>
+				</p>
 			</div>
 		<?php
 

--- a/includes/class-meta-box-post-type.php
+++ b/includes/class-meta-box-post-type.php
@@ -73,6 +73,7 @@ if ( ! class_exists( 'CMB2_Meta_Box_Post_Type' ) ) {
 				'not_found'           => __( 'Not found', 'cmb2-admin-extension' ),
 				'not_found_in_trash'  => __( 'Not found in Trash', 'cmb2-admin-extension' ),
 			);
+
 			$args = array(
 				'label'               => __( 'meta_box', 'cmb2-admin-extension' ),
 				'description'         => __( 'Create custom meta boxes and fields', 'cmb2-admin-extension' ),
@@ -208,6 +209,7 @@ if ( ! class_exists( 'CMB2_Meta_Box_Post_Type' ) ) {
 					'add_upload_file_text'     => 'cmb_hide_field file',
 					'default_value_text'       => 'default_value',
 				);
+
 				$classes = $this->conditionally_add_class( $field->args['_id'], $field_classes, $classes );
 			}
 			return $classes;
@@ -270,7 +272,7 @@ if ( ! class_exists( 'CMB2_Meta_Box_Post_Type' ) ) {
 				'options' => $post_types,
 				'inline'  => true,
 			) );
-			
+
 			$cmb->add_field( array(
 				'name'    => __( 'Post IDs', 'cmb2-admin-extension' ),
 				'desc'    => __( 'Enter the post ids that you want to add this meta box to. Separate multiple entries with a comma. Leave blank for the meta box to show up on all post IDs.', 'cmb2-admin-extension' ),
@@ -278,7 +280,7 @@ if ( ! class_exists( 'CMB2_Meta_Box_Post_Type' ) ) {
 				'type'    => 'text',
 				'inline'  => true,
 			) );
-			
+
 			$cmb->add_field( array(
 				'name'    => __( 'Priority', 'cmb2-admin-extension' ),
 				'desc'    => __( 'This is to control what order your meta box appears in.', 'cmb2-admin-extension' ),
@@ -339,7 +341,7 @@ if ( ! class_exists( 'CMB2_Meta_Box_Post_Type' ) ) {
 		 */
 		public function init_custom_field_settings() {
 
-			$prefix = $this->prefix;
+			$prefix    = $this->prefix;
 			$cmb_group = new_cmb2_box( array(
 				'id'           => $prefix . 'custom_fields',
 				'title'        => __( 'Custom Field Settings', 'cmb2-admin-extension' ),
@@ -398,7 +400,7 @@ if ( ! class_exists( 'CMB2_Meta_Box_Post_Type' ) ) {
 					'text_date_timestamp'              => 'text_date_timestamp: ' . __( 'Date Picker (UNIX timestamp)', 'cmb2-admin-extension' ),
 					'text_datetime_timestamp'          => 'text_datetime_timestamp: ' . __( 'Text Date/Time Picker Combo (UNIX timestamp)', 'cmb2-admin-extension' ),
 					'text_datetime_timestamp_timezone' => 'text_datetime_timestamp_timezone: ' . __( 'Text Date/Time Picker/Time zone Combo (serialized DateTime object)', 'cmb2-admin-extension' ),
-					'color_picker'                      => 'colorpicker: ' . __( 'Color picker', 'cmb2-admin-extension' ),
+					'color_picker'                     => 'colorpicker: ' . __( 'Color picker', 'cmb2-admin-extension' ),
 					'radio'                            => 'radio: ' . __( 'Radio Buttons', 'cmb2-admin-extension' ) . ' *',
 					'radio_inline'                     => 'radio_inline: ' . __( 'Radio Buttons Inline', 'cmb2-admin-extension' ) . ' *',
 					'taxonomy_radio'                   => 'taxonomy_radio: ' . __( 'Taxonomy Radio Buttons', 'cmb2-admin-extension' ) . ' *',

--- a/includes/class-meta-box-settings.php
+++ b/includes/class-meta-box-settings.php
@@ -106,7 +106,7 @@ if ( ! class_exists( 'CMB2_Meta_Box_Settings' ) ) {
 		 */
 		public function user_options() {
 
-			$users = get_users();
+			$users        = get_users();
 			$user_options = array();
 			foreach ( $users as $user ) {
 

--- a/includes/class-meta-box.php
+++ b/includes/class-meta-box.php
@@ -67,7 +67,7 @@ if ( ! class_exists( 'CMB2_Meta_Box' ) ) {
 		public static function get_instance() {
 			// If the single instance hasn't been set, set it now.
 			if ( self::$instance === null ) {
-				self::$instance = new self;
+				self::$instance = new self();
 			}
 
 			return self::$instance;
@@ -83,7 +83,7 @@ if ( ! class_exists( 'CMB2_Meta_Box' ) ) {
 
 			$cmb2_settings = get_option( '_cmb2_settings' );
 
-			if ( empty( $cmb2_settings ) || current_user_can('administrator')) {
+			if ( empty( $cmb2_settings ) || current_user_can( 'administrator' ) ) {
 				// No settings saved.
 				return true;
 			}
@@ -192,7 +192,7 @@ if ( ! class_exists( 'CMB2_Meta_Box' ) ) {
 		 * Conditional to check if the field argument should be added..
 		 *
 		 * @since 1.1.4
-		 * @param string $field_options string of options for fields liek select.
+		 * @param string $field_options String of options for fields liek select.
 		 */
 		private function add_option_arg( $field_options ) {
 
@@ -251,10 +251,10 @@ if ( ! class_exists( 'CMB2_Meta_Box' ) ) {
 		 * @since  1.1.4
 		 * @param  array  $field      Field definition.
 		 * @param  string $field_type A CMB2 field type.
-		 * @param  string $field_key  $field key to check.
+		 * @param  string $field_key  Field key to check.
 		 * @return boolean.
 		 */
-		static function should_add_arg( $field, $field_type, $field_key ) {
+		public static function should_add_arg( $field, $field_type, $field_key ) {
 
 			return ( $field['_cmb2_field_type_select'] === $field_type && ( ! empty( $field[ $field_key ] ) && $field[ $field_key ] !== '' ) );
 		}
@@ -284,8 +284,8 @@ if ( ! class_exists( 'CMB2_Meta_Box' ) ) {
 				$title          = get_the_title( $metabox_id );
 				$id             = str_replace( '-', '_', $user_meta_box->post_name );
 				$post_type      = cmbf( $metabox_id, $prefix . 'post_type_multicheckbox' );
-				$post_id_text	= cmbf( $metabox_id, $prefix . 'post_id_text' );
-				$show_on 	= explode(',', $post_id_text);
+				$post_id_text   = cmbf( $metabox_id, $prefix . 'post_id_text' );
+				$show_on        = explode( ',', $post_id_text );
 				$context        = cmbf( $metabox_id, $prefix . 'context_radio' );
 				$priority       = cmbf( $metabox_id, $prefix . 'priority_radio' );
 				$show_names     = cmbf( $metabox_id, $prefix . 'show_names' ) === 'on' ? true : false;
@@ -296,29 +296,32 @@ if ( ! class_exists( 'CMB2_Meta_Box' ) ) {
 				/**
 				 * Initiate the metabox.
 				 */
-				if ($post_id_text !== ''){
-				${ 'cmb_' . $id } = new_cmb2_box( array(
-					'id'           => $id,
-					'title'        => $title,
-					'object_types' => $post_type, // Post type.
-					'show_on'      => array( 'key' => 'id', 'value' => $show_on ),
-					'context'      => $context,
-					'priority'     => $priority,
-					'show_names'   => $show_names,
-					'cmb_styles'   => $disable_styles,
-					'closed'       => $closed,
-				) );
+				if ( $post_id_text !== '' ) {
+					${ 'cmb_' . $id } = new_cmb2_box( array(
+						'id'           => $id,
+						'title'        => $title,
+						'object_types' => $post_type, // Post type.
+						'show_on'      => array(
+							'key'   => 'id',
+							'value' => $show_on,
+						),
+						'context'      => $context,
+						'priority'     => $priority,
+						'show_names'   => $show_names,
+						'cmb_styles'   => $disable_styles,
+						'closed'       => $closed,
+					) );
 				} else {
-				${ 'cmb_' . $id } = new_cmb2_box( array(
-					'id'           => $id,
-					'title'        => $title,
-					'object_types' => $post_type, // Post type.
-					'context'      => $context,
-					'priority'     => $priority,
-					'show_names'   => $show_names,
-					'cmb_styles'   => $disable_styles,
-					'closed'       => $closed,
-				) );
+					${ 'cmb_' . $id } = new_cmb2_box( array(
+						'id'           => $id,
+						'title'        => $title,
+						'object_types' => $post_type, // Post type.
+						'context'      => $context,
+						'priority'     => $priority,
+						'show_names'   => $show_names,
+						'cmb_styles'   => $disable_styles,
+						'closed'       => $closed,
+					) );
 				}
 
 				foreach ( $fields as $field ) {
@@ -331,9 +334,11 @@ if ( ! class_exists( 'CMB2_Meta_Box' ) ) {
 						'_cmb2_repeatable_checkbox' => null,
 						'_cmb2_none_checkbox'       => null,
 					) );
+
 					$this->field = $field;
 					$field_id    = '_' . strtolower( str_replace( ' ', '_', $field['_cmb2_name_text'] ) );
-					$this->field_args  = array(
+
+					$this->field_args = array(
 						'name' => $field['_cmb2_name_text'],
 						'desc' => $field['_cmb2_decription_textarea'],
 						'id'   => $field_id,
@@ -359,14 +364,14 @@ if ( ! class_exists( 'CMB2_Meta_Box' ) ) {
 						$field_args['show_option_none'] = true;
 					}
 					$should_add = array(
-						'text_url' => array( 'protocols', '_cmb2_protocols_checkbox' ),
-						'text_money' => array( 'before_field', '_cmb2_currency_text' ),
-						'text_time' => array( 'time_format', '_cmb2_time_format' ),
+						'text_url'                         => array( 'protocols', '_cmb2_protocols_checkbox' ),
+						'text_money'                       => array( 'before_field', '_cmb2_currency_text' ),
+						'text_time'                        => array( 'time_format', '_cmb2_time_format' ),
 						'text_datetime_timestamp_timezone' => array( 'time_format', '_cmb2_time_format' ),
-						'text_datetime_timestamp' => array( 'time_format', '_cmb2_time_format' ),
-						'text_date' => array( 'date_format', '_cmb2_date_format' ),
-						'text_date_timestamp' => array( 'date_format', '_cmb2_date_format' ),
-						'select_timezone' => array( 'timezone_meta_key', '_cmb2_time_zone_key_select' ),
+						'text_datetime_timestamp'          => array( 'time_format', '_cmb2_time_format' ),
+						'text_date'                        => array( 'date_format', '_cmb2_date_format' ),
+						'text_date_timestamp'              => array( 'date_format', '_cmb2_date_format' ),
+						'select_timezone'                  => array( 'timezone_meta_key', '_cmb2_time_zone_key_select' ),
 						'text_datetime_timestamp_timezone' => array( 'timezone_meta_key', '_cmb2_time_zone_key_select' ),
 						// '' => array( 'options', array( 'add_upload_file_text', '_cmb2_add_upload_file_text' ) ),
 					);


### PR DESCRIPTION
### Build/Travis/PHPCS: update the travis script & PHPCS ruleset

* Travis: Allow for changes in the Travis images which impact how builds against PHP 5.2 need to be run.
* Travis: Test against PHP 7.2
* Travis: Adjust the `before_script` and `script` to account for changes in PHPCS 3.x.
* Travis: Adjust the `before_script` to account for changes in the PHPCompatibility standard.
* Travis: Move most PHPCS command line arguments to the PHPCS ruleset.
* Travis: Ignore warnings for the PHPCS build check, but do show them.
* PHPCS: Rename the PHPCS ruleset file to be in line with the latest best practices and allow PHPCS to find it automatically.
* PHPCS: escape characters in exclude patterns which have special meaning.


### PHPCS: update ruleset

* Update the errorcode of an exclusion which has changed a while back.
* Add adjusted configuration for the `Arrays.MultipleStatementAlignment` sniff
* Exclude the "strict class file names" rule.


### Update codebase to comply with the latest coding standards 